### PR TITLE
feat: comply with risc-v specification on boot

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ endif
 
 # riscv64-unknown-elf- or riscv64-linux-gnu-
 # perhaps in /opt/riscv/bin
-#TOOLPREFIX = 
+#TOOLPREFIX =
 
 # Try to infer the correct TOOLPREFIX if not set
 ifndef TOOLPREFIX
@@ -67,7 +67,7 @@ LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 
-CFLAGS = -Wall -Werror -O -fno-omit-frame-pointer -ggdb
+CFLAGS = -Wall -O -fno-omit-frame-pointer -ggdb
 
 ifdef LAB
 LABUPPER = $(shell echo $(LAB) | tr a-z A-Z)
@@ -91,7 +91,7 @@ endif
 LDFLAGS = -z max-page-size=4096
 
 $K/kernel: $(OBJS) $K/kernel.ld $U/initcode
-	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS) 
+	$(LD) $(LDFLAGS) -T $K/kernel.ld -o $K/kernel $(OBJS)
 	$(OBJDUMP) -S $K/kernel > $K/kernel.asm
 	$(OBJDUMP) -t $K/kernel | sed '1,/SYMBOL TABLE/d; s/ .* / /; /^$$/d' > $K/kernel.sym
 
@@ -183,7 +183,7 @@ fs.img: mkfs/mkfs README $(UEXTRA) $(UPROGS)
 
 -include kernel/*.d user/*.d
 
-clean: 
+clean:
 	rm -f *.tex *.dvi *.idx *.aux *.log *.ind *.ilg \
 	*/*.o */*.d */*.asm */*.sym \
 	$U/initcode $U/initcode.out $K/kernel fs.img \

--- a/kernel/kernelvec.S
+++ b/kernel/kernelvec.S
@@ -85,6 +85,11 @@ kernelvec:
         // return to whatever we were doing in the kernel.
         sret
 
+// help: if you hit these, an unexpected exception/interrupt happened in M-mode.
+// use `info registers` in the qemu monitor to get the relevant CSRs.
+unexpected_exc: j unexpected_exc
+unexpected_int: j unexpected_int
+
         #
         # machine-mode timer interrupt.
         #
@@ -95,11 +100,20 @@ timervec:
         # scratch[0,8,16] : register save area.
         # scratch[32] : address of CLINT's MTIMECMP register.
         # scratch[40] : desired interval between interrupts.
-        
+
         csrrw a0, mscratch, a0
         sd a1, 0(a0)
         sd a2, 8(a0)
         sd a3, 16(a0)
+
+        csrr a1, mcause
+        // we should not get exceptions in M-mode. if we do, something went
+        // very wrong and we should explicitly jump to an infinite loop for the
+        // purpose.
+        bgez a1, unexpected_exc
+        li a2, (1<<63 | 7)
+        // likewise for any interrupts that are not machine timer interrupts.
+        bne a1, a2, unexpected_int
 
         # schedule the next timer interrupt
         # by adding interval to mtimecmp.

--- a/kernel/riscv.h
+++ b/kernel/riscv.h
@@ -23,7 +23,7 @@ r_mstatus()
   return x;
 }
 
-static inline void 
+static inline void
 w_mstatus(uint64 x)
 {
   asm volatile("csrw mstatus, %0" : : "r" (x));
@@ -32,10 +32,33 @@ w_mstatus(uint64 x)
 // machine exception program counter, holds the
 // instruction address to which a return from
 // exception will go.
-static inline void 
+static inline void
 w_mepc(uint64 x)
 {
   asm volatile("csrw mepc, %0" : : "r" (x));
+}
+
+// physical memory protection CSRs
+#define PMP_R (1L << 0)
+#define PMP_W (1L << 1)
+#define PMP_X (1L << 2)
+// naturally aligned power of two
+#define PMP_MATCH_NAPOT (3L << 3)
+
+// we only implement accessing one PMP register
+
+// write to the first 8 PMP configuration registers
+static inline void
+w_pmpcfg0(uint64 x)
+{
+  asm volatile("csrw pmpcfg0, %0" : : "r" (x));
+}
+
+// write to the address for PMP region 0
+static inline void
+w_pmpaddr0(uint64 x)
+{
+  asm volatile("csrw pmpaddr0, %0" : : "r" (x));
 }
 
 // Supervisor Status Register, sstatus
@@ -54,7 +77,7 @@ r_sstatus()
   return x;
 }
 
-static inline void 
+static inline void
 w_sstatus(uint64 x)
 {
   asm volatile("csrw sstatus, %0" : : "r" (x));
@@ -69,7 +92,7 @@ r_sip()
   return x;
 }
 
-static inline void 
+static inline void
 w_sip(uint64 x)
 {
   asm volatile("csrw sip, %0" : : "r" (x));
@@ -87,7 +110,7 @@ r_sie()
   return x;
 }
 
-static inline void 
+static inline void
 w_sie(uint64 x)
 {
   asm volatile("csrw sie, %0" : : "r" (x));
@@ -105,7 +128,7 @@ r_mie()
   return x;
 }
 
-static inline void 
+static inline void
 w_mie(uint64 x)
 {
   asm volatile("csrw mie, %0" : : "r" (x));
@@ -114,7 +137,7 @@ w_mie(uint64 x)
 // machine exception program counter, holds the
 // instruction address to which a return from
 // exception will go.
-static inline void 
+static inline void
 w_sepc(uint64 x)
 {
   asm volatile("csrw sepc, %0" : : "r" (x));
@@ -137,7 +160,7 @@ r_medeleg()
   return x;
 }
 
-static inline void 
+static inline void
 w_medeleg(uint64 x)
 {
   asm volatile("csrw medeleg, %0" : : "r" (x));
@@ -152,7 +175,7 @@ r_mideleg()
   return x;
 }
 
-static inline void 
+static inline void
 w_mideleg(uint64 x)
 {
   asm volatile("csrw mideleg, %0" : : "r" (x));
@@ -160,7 +183,7 @@ w_mideleg(uint64 x)
 
 // Supervisor Trap-Vector Base Address
 // low two bits are mode.
-static inline void 
+static inline void
 w_stvec(uint64 x)
 {
   asm volatile("csrw stvec, %0" : : "r" (x));
@@ -175,7 +198,7 @@ r_stvec()
 }
 
 // Machine-mode interrupt vector
-static inline void 
+static inline void
 w_mtvec(uint64 x)
 {
   asm volatile("csrw mtvec, %0" : : "r" (x));
@@ -188,7 +211,7 @@ w_mtvec(uint64 x)
 
 // supervisor address translation and protection;
 // holds the address of the page table.
-static inline void 
+static inline void
 w_satp(uint64 x)
 {
   asm volatile("csrw satp, %0" : : "r" (x));
@@ -203,13 +226,13 @@ r_satp()
 }
 
 // Supervisor Scratch register, for early trap handler in trampoline.S.
-static inline void 
+static inline void
 w_sscratch(uint64 x)
 {
   asm volatile("csrw sscratch, %0" : : "r" (x));
 }
 
-static inline void 
+static inline void
 w_mscratch(uint64 x)
 {
   asm volatile("csrw mscratch, %0" : : "r" (x));
@@ -234,7 +257,7 @@ r_stval()
 }
 
 // Machine-mode Counter-Enable
-static inline void 
+static inline void
 w_mcounteren(uint64 x)
 {
   asm volatile("csrw mcounteren, %0" : : "r" (x));
@@ -297,7 +320,7 @@ r_tp()
   return x;
 }
 
-static inline void 
+static inline void
 w_tp(uint64 x)
 {
   asm volatile("mv tp, %0" : : "r" (x));

--- a/kernel/start.c
+++ b/kernel/start.c
@@ -7,6 +7,8 @@
 void main();
 void timerinit();
 
+static void pmpinit();
+
 // entry.S needs one stack per CPU.
 __attribute__ ((aligned (16))) char stack0[4096 * NCPU];
 
@@ -45,8 +47,34 @@ start()
   int id = r_mhartid();
   w_tp(id);
 
+  // allow access to all physical memory by S mode
+  pmpinit();
+
   // switch to supervisor mode and jump to main().
   asm volatile("mret");
+}
+
+// configures the pmp registers trivially so we can boot. it is not permitted
+// to jump to S mode without having these configured as instruction fetch will
+// fail, however we do not actually use them for protection in xv6, so we just
+// need to put something trivial there.
+//
+// see section 3.6.1 "Physical Memory Protection CSRs" in the RISC-V privileged
+// specification (v20190608)
+//
+// "If no PMP entry matches an M-mode access, the access succeeds. If no PMP
+// entry matches an S-mode or U-mode access, but at least one PMP entry is
+// implemented, the access fails." (3.6.1)
+static void
+pmpinit()
+{
+  // see figure 3.27 "PMP address register format, RV64" and table 3.10 "NAPOT
+  // range encoding in PMP address and configuration registers" in the RISC-V
+  // privileged specification
+  // we set the bits such that this matches any 56-bit physical address
+  w_pmpaddr0((~0ULL) >> 10);
+  // then we allow the access
+  w_pmpcfg0(PMP_R | PMP_W | PMP_X | PMP_MATCH_NAPOT);
 }
 
 // set up to receive timer interrupts in machine mode,


### PR DESCRIPTION
## Description ⚙️🛠️
- According to the spec, if no PMP registers any access to memory including fetch from S- or U- mode should fail  (see section 3.6.1 of the RISC-V privileged spec).
